### PR TITLE
Removed malloc.h not convertible with macos

### DIFF
--- a/src/ptrie/binarywrapper.h
+++ b/src/ptrie/binarywrapper.h
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <limits>
 #include <stdlib.h>
-#include <malloc.h>
 #include <stdint.h>
 
 #ifndef BINARYWRAPPER_H


### PR DESCRIPTION
malloc should be in stdlib.h